### PR TITLE
fix(etb-all-clients): copy geth instrumentation symbols into image

### DIFF
--- a/deps/dockers/base-images/etb-all-clients_minimal-fuzz.Dockerfile
+++ b/deps/dockers/base-images/etb-all-clients_minimal-fuzz.Dockerfile
@@ -15,6 +15,7 @@ FROM etb-client-runner:latest as base
 
 COPY --from=geth_bb_builder /usr/local/bin/geth /usr/local/bin/geth
 COPY --from=geth_bb_builder /geth.version /geth.version
+COPY --from=geth_bb_builder /opt/antithesis/symbols/* /opt/antithesis/symbols/
 
 # tx-fuzzer
 COPY --from=txfuzzer_builder /run/tx-fuzz.bin /usr/local/bin/tx-fuzz


### PR DESCRIPTION
Geth bad block creator is being instrumented, but its symbols were not being copied into the various `etb-all-clients` images.

This was causing issues with our platform, which was expecting to find the symbols files.